### PR TITLE
Create example for Contrail Windows without Openstack deployment

### DIFF
--- a/config/instances.yaml.bms_win_example
+++ b/config/instances.yaml.bms_win_example
@@ -26,6 +26,6 @@ contrail_configuration:
   WINDOWS_ENABLE_TEST_SIGNING:
   WINDOWS_DEBUG_DLLS_PATH: ~/dlls # this folder should contain debug DLLs
 
-  AUTH_MODE: keystone
-  KEYSTONE_AUTH_HOST: 192.168.1.100 # supply IP of keystone host
-  KEYSTONE_AUTH_ADMIN_PASSWORD: c0ntrail123 # supply real admin password
+  AUTH_MODE: keystone # Defaults to noauth. Specify if controller uses keystone for authentication
+  KEYSTONE_AUTH_HOST: 192.168.1.100 # Optional. Supply IP of keystone host if AUTH_MODE is keystone
+  KEYSTONE_AUTH_ADMIN_PASSWORD: c0ntrail123 # Optional. Supply real admin password if AUTH_MODE is keystone

--- a/config/instances.yaml.bms_win_no_openstack_example
+++ b/config/instances.yaml.bms_win_no_openstack_example
@@ -1,0 +1,45 @@
+provider_config:
+  bms:
+    ssh_pwd: Contrail123!
+    ssh_user: root
+
+  bms_win:
+    ansible_user: Administrator
+    ansible_password: Contrail123!
+
+instances:
+  ctrl:
+    provider: bms
+    ip: 192.168.1.100
+    roles:
+      config_database:
+      config:
+      control:
+      analytics_database:
+      analytics:
+      webui:
+
+  win_compute1:
+    provider: bms_win
+    ip: 192.168.1.101
+    roles:
+      vrouter:
+      win_docker_driver:
+
+  win_compute2:
+    provider: bms_win
+    ip: 192.168.1.102
+    roles:
+      vrouter:
+      win_docker_driver:
+
+global_configuration:
+  CONTAINER_REGISTRY: opencontrailnightly
+  WINDOWS_CONTAINER_REGISTRY: mclapinski
+
+contrail_configuration:
+  CONTRAIL_VERSION: latest
+  PHYSICAL_INTERFACE: ens192
+  WINDOWS_PHYSICAL_INTERFACE: Ethernet1
+  WINDOWS_ENABLE_TEST_SIGNING:
+  WINDOWS_DEBUG_DLLS_PATH: ~/dlls

--- a/playbooks/roles/install_contrail/tasks/create_win_docker_driver.yml
+++ b/playbooks/roles/install_contrail/tasks/create_win_docker_driver.yml
@@ -15,6 +15,7 @@
       - '-controllerIP {{ contrail_configuration.CONFIG_NODES }}'
       - '-adapter "{{ contrail_configuration.WINDOWS_PHYSICAL_INTERFACE }}"'
       - '-logLevel Debug'
+      - '-authMethod {{ contrail_configuration.AUTH_MODE }}'
 
 - name: add keystone args if needed
   set_fact:


### PR DESCRIPTION
Contrail Windows should be able to be deployed without openstack as authentication supplier